### PR TITLE
Don't Use Global Sketch Vars

### DIFF
--- a/Fill Murray.sketchplugin
+++ b/Fill Murray.sketchplugin
@@ -45,7 +45,7 @@ function handleAlertResponse(alert, responseCode, el) {
     var size = opts.width + '/' + opts.height;
     var url = baseUrl + type + size;
 
-    doc.showMessage('Creating a ' + size + 'px image from fillmurray.com...');
+    sketch.doc.showMessage('Creating a ' + size + 'px image from fillmurray.com...');
 
     createAndPlaceImg(url, size, el);
   }

--- a/Hhhhold.sketchplugin
+++ b/Hhhhold.sketchplugin
@@ -56,7 +56,7 @@ function handleAlertResponse(alert, responseCode, el) {
     var size = opts.width + 'x' + opts.height;
     var url = baseUrl + size + type;
 
-    doc.showMessage('Turning loose a ' + size + 'px image from hhhold.com...');
+    sketch.doc.showMessage('Turning loose a ' + size + 'px image from hhhold.com...');
 
     createAndPlaceImg(url, size, el);
   }

--- a/Lorem Pixel.sketchplugin
+++ b/Lorem Pixel.sketchplugin
@@ -65,7 +65,7 @@ function handleAlertResponse(alert, responseCode, el) {
     var size = opts.width + '/' + opts.height;
     var url = baseUrl + size + type;
 
-    doc.showMessage('Creating a ' + size + 'px image from lorempixel.com...');
+    sketch.doc.showMessage('Creating a ' + size + 'px image from lorempixel.com...');
 
     createAndPlaceImg(url, size, el);
   }

--- a/Place Cage.sketchplugin
+++ b/Place Cage.sketchplugin
@@ -52,7 +52,7 @@ function handleAlertResponse(alert, responseCode, el) {
     var size = opts.width + '/' + opts.height;
     var url = baseUrl + type + size;
 
-    doc.showMessage('Creating a ' + size + 'px image from placecage.com...');
+    sketch.doc.showMessage('Creating a ' + size + 'px image from placecage.com...');
 
     createAndPlaceImg(url, size, el);
   }

--- a/Placehold.it.sketchplugin
+++ b/Placehold.it.sketchplugin
@@ -51,7 +51,7 @@ function handleAlertResponse(alert, responseCode, el) {
     var text = '&text=' + encodeURIComponent(opts.txt);
     var url = baseUrl + size + '/' + color + text;
 
-    doc.showMessage('Creating a ' + size + 'px image from placehold.it...');
+    sketch.doc.showMessage('Creating a ' + size + 'px image from placehold.it...');
 
     createAndPlaceImg(url, size, el);
   }

--- a/Placekitten.sketchplugin
+++ b/Placekitten.sketchplugin
@@ -45,7 +45,7 @@ function handleAlertResponse(alert, responseCode, el) {
     var size = opts.width + '/' + opts.height;
     var url = baseUrl + type + size;
 
-    doc.showMessage('Creating a ' + size + 'px image from placekitten.com...');
+    sketch.doc.showMessage('Creating a ' + size + 'px image from placekitten.com...');
 
     createAndPlaceImg(url, size, el);
   }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,17 +1,17 @@
-// I don't know where it is defined, but scriptPath is available here
-// and is a absolute path from ~ to the parent directory of the .sketchplugin
-var pluginPath = scriptPath.substring(0, scriptPath.lastIndexOf('/'));
+// sketch.scriptPath is an absolute path from ~ to the parent directory of the .sketchplugin
+var pluginPath = sketch.scriptPath.substring(0, sketch.scriptPath.lastIndexOf('/'));
 
 // Determine if we're appending the image to an artboard, group, or the page.
 function getElToAppendTo () {
   var app = NSApplication.sharedApplication();
   var el = null;
+  var s = sketch.selection;
 
-  if (selection.count() == 0) {
-    el = doc.currentPage();
+  if (s.count() == 0) {
+    el = sketch.doc.currentPage();
   }
   else {
-    var type = selection[0].className();
+    var type = s[0].className();
 
     if (type == 'MSArtboardGroup' || type == 'MSLayerGroup') {
       el = selection[0];


### PR DESCRIPTION
fixes #6 

Also move away from `doc` and `selection` global vars in favor of `sketch.doc` and `sketch.selection`

See http://mail.sketchplugins.com/pipermail/dev_sketchplugins.com/2014-May/000339.html
