### PR TITLE
Make this work for Sketch 3.2

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -73,7 +73,7 @@ function addImgToCanvas (el, img, layerName) {
   var imageCollection = el.documentData().images();
   var imageData = imageCollection.addImage_convertColourspace(img, false);
   var newImage = MSBitmapLayer.alloc().initWithImage_parentFrame_name(imageData, el.frame(), layerName);
-  el.addLayer(newImage);
+  el.addLayers([newImage]);
   return newImage;
 }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -71,7 +71,7 @@ function valAtIndex (view, index) {
 // Creates a new bitmap image and adds it to the Layer group
 function addImgToCanvas (el, img, layerName) {
   var imageCollection = el.documentData().images();
-  var imageData = imageCollection.addImage_name_convertColourspace(img, layerName, false);
+  var imageData = imageCollection.addImage_convertColourspace(img, false);
   var newImage = MSBitmapLayer.alloc().initWithImage_parentFrame_name(imageData, el.frame(), layerName);
   el.addLayer(newImage);
   return newImage;


### PR DESCRIPTION
refs #14 

There were two breaking api changes in 3.2. 

First. The–apparent–removal of the name arg in `addImage_name_convertColourspace` method on MSImageCollection. It now works without the `name`, so `addImage_convertColourspace`.

Second. The removal of the `addLayer:layer` method. As if 3.2 it is now `addLayers:[layer1]` [See](http://mail.sketchplugins.com/pipermail/dev_sketchplugins.com/2014-December/000978.html)
