### PR TITLE
Fix for missing MSImageProxy in Sketch 3.6.1

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -72,9 +72,10 @@ function createAndPlaceImg (url, size, el) {
   var image = NSImage.alloc().initWithContentsOfURL(NSURL.URLWithString(url));
   var layerName = size + ' Placeholder Img';
   var doc = context.document;
+  var imageData = [[MSImageData alloc] initWithImage:image convertColorSpace:false];
   var layer = MSBitmapLayer.alloc().initWithFrame_image(
     NSMakeRect(0, 0, image.size().width, image.size().height),
-    MSImageProxy.proxyWithImage(image)
+    imageData
   );
   var page = doc.currentPage();
   var artboard = page.currentArtboard();


### PR DESCRIPTION
Use an MSImageData instead of an MSImageProxy (at increased memory cost, but Day Player works again)
