### PR TITLE
Add passthrough methods in index.cocoascript

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,31 +10,31 @@
     {
       "name": "Unsplash.it",
       "script": "index.cocoascript",
-      "handler": "unsplashIt",
+      "handler": "_unsplashIt",
       "identifier": "unsplash-it"
     },
     {
       "name": "Fill Murray",
       "script": "index.cocoascript",
-      "handler": "fillMurray",
+      "handler": "_fillMurray",
       "identifier": "fill-murray"
     },
     {
       "name": "Place Cage",
       "script": "index.cocoascript",
-      "handler": "placeCage",
+      "handler": "_placeCage",
       "identifier": "place-cage"
     },
     {
       "name": "Placehold.it",
       "script": "index.cocoascript",
-      "handler": "placeHoldIt",
+      "handler": "_placeHoldIt",
       "identifier": "place-hold-it"
     },
     {
       "name": "Placekitten",
       "script": "index.cocoascript",
-      "handler": "placeKitten",
+      "handler": "_placeKitten",
       "identifier": "place-kitten"
     }
   ],

--- a/src/index.cocoascript
+++ b/src/index.cocoascript
@@ -8,3 +8,10 @@
 @import './handlers/placeHoldIt.js';
 @import './handlers/placeKitten.js';
 @import './handlers/unsplashIt.js';
+
+var _fillMurray 	= fillMurray
+var _placeCage 		= placeCage
+var _placeHoldIt 	= placeHoldIt
+var _placeKitten 	= placeKitten
+var _unsplashIt 	= unsplashIt
+


### PR DESCRIPTION
Hey,

Figured out a solution for the issue discussed here: https://github.com/tylergaw/day-player/issues/37

Apparently in recent updates sketch only searches the `script` file for the `handler` method specified in `manifest.json` Because all handlers were imported your plugin wouldn't run consistently.

I prefixed the handlers in manifest.json and pass them through in index.cocoapods to the correct methods. For me this fixed the problem.

Hope this helps someone. Great plugin 👍 