### PR TITLE
Set www prefix for fillMurray and fillCage

### DIFF
--- a/src/handlers/fillMurray.js
+++ b/src/handlers/fillMurray.js
@@ -30,7 +30,7 @@ const fillMurray = createPluginHandler(function(props) {
   const onConfirm = createConfirmHandler({
     api: props.api,
     group: props.target.group,
-    host: 'fillmurray.com',
+    host: 'www.fillmurray.com',
     initOpts: initOpts,
     urlBuilder: function(parts) {
       const base = `${parts.protocol}${parts.host}`;

--- a/src/handlers/placeCage.js
+++ b/src/handlers/placeCage.js
@@ -30,7 +30,7 @@ const placeCage = createPluginHandler(function(props) {
   const onConfirm = createConfirmHandler({
     api: props.api,
     group: props.target.group,
-    host: 'placecage.com',
+    host: 'www.placecage.com',
     initOpts: initOpts,
     urlBuilder: function(parts) {
       const base = `${parts.protocol}${parts.host}`;


### PR DESCRIPTION
Due to a configuration error on fillMurray.com and fillCage.com domains https requests without a **www.** prefix get downgraded to http. For security reasons Sketch drops any non https request which is not handled by the plugin. To fix this behaviour I added a www. prefix, which are not downgraded when connected to directly. Handling dropped request should be fixed in a future update